### PR TITLE
Bug fix for PESSTOEFOSC2dSPEC on some systems

### DIFF
--- a/trunk/src/ntt/util.py
+++ b/trunk/src/ntt/util.py
@@ -1155,7 +1155,8 @@ def spectraresolution2(img0, ww=25):
     ff.write(cursor)
     ff.close()
     from pyraf import iraf
-
+    from iraf import onedspec
+    
     aaa = iraf.noao.onedspec.bplot(
         'new3.fits', cursor='_cursor', spec2='', new_ima='', overwri='yes', Stdout=1)
     fw = []


### PR DESCRIPTION
When I run pipeline on my linux workstation with anaconda python 2.7, I get the following error at the wavelength calibration stage:
AttributeError: Package onedspec has not been loaded; no tasks are defined.

Adding this line fixes the bug